### PR TITLE
[FLINK-17077] Use FLINK_CONF_DIR environment variable to locate flink-conf.yaml

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,8 @@
 
 # If unspecified, the hostname of the container is taken as the JobManager address
 JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
-CONF_FILE="${FLINK_HOME}/conf/flink-conf.yaml"
+FLINK_CONF_DIR=${FLINK_CONF_DIR:-${FLINK_HOME}/conf}
+CONF_FILE="${FLINK_CONF_DIR}/flink-conf.yaml"
 
 drop_privs_cmd() {
     if [ $(id -u) != 0 ]; then


### PR DESCRIPTION
To use flink-conf.yaml outside Flink home directory, we should use FLINK_CONF_DIR.
But despite of FLINK_CONF_DIR is set, docker-entrypoint.sh doesn't know the location of which user want. Therefore it would be good to use FLINK_CONF_DIR for the location of flink-conf.yaml, if user provide it.