### PR TITLE
[FLINK-17367] Add configurable download URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.swp
 .idea
+dev

--- a/1.10/scala_2.11-debian/Dockerfile
+++ b/1.10/scala_2.11-debian/Dockerfile
@@ -46,7 +46,8 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc \
-    GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8
+    GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8 \
+    SKIP_GPG=false
 
 # Prepare environment
 ENV FLINK_HOME=/opt/flink
@@ -58,19 +59,21 @@ WORKDIR $FLINK_HOME
 # Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
-  wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
   \
-  export GNUPGHOME="$(mktemp -d)"; \
-  for server in ha.pool.sks-keyservers.net $(shuf -e \
-                          hkp://p80.pool.sks-keyservers.net:80 \
-                          keyserver.ubuntu.com \
-                          hkp://keyserver.ubuntu.com:80 \
-                          pgp.mit.edu) ; do \
-      gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
-  done && \
-  gpg --batch --verify flink.tgz.asc flink.tgz; \
-  gpgconf --kill all; \
-  rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  if [ "$SKIP_GPG" = "false" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/1.10/scala_2.11-debian/Dockerfile
+++ b/1.10/scala_2.11-debian/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_VERSION=1.10.0 \
-    SCALA_VERSION=2.11 \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc \
     GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8
 
 # Prepare environment
@@ -54,11 +54,6 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
-
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-# Not all mirrors have the .asc files
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
-    FLINK_ASC_URL=https://www.apache.org/dist/${FLINK_URL_FILE_PATH}.asc
 
 # Install Flink
 RUN set -ex; \

--- a/1.10/scala_2.12-debian/Dockerfile
+++ b/1.10/scala_2.12-debian/Dockerfile
@@ -46,7 +46,8 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc \
-    GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8
+    GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8 \
+    SKIP_GPG=false
 
 # Prepare environment
 ENV FLINK_HOME=/opt/flink
@@ -58,19 +59,21 @@ WORKDIR $FLINK_HOME
 # Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
-  wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
   \
-  export GNUPGHOME="$(mktemp -d)"; \
-  for server in ha.pool.sks-keyservers.net $(shuf -e \
-                          hkp://p80.pool.sks-keyservers.net:80 \
-                          keyserver.ubuntu.com \
-                          hkp://keyserver.ubuntu.com:80 \
-                          pgp.mit.edu) ; do \
-      gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
-  done && \
-  gpg --batch --verify flink.tgz.asc flink.tgz; \
-  gpgconf --kill all; \
-  rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  if [ "$SKIP_GPG" = "false" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/1.10/scala_2.12-debian/Dockerfile
+++ b/1.10/scala_2.12-debian/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_VERSION=1.10.0 \
-    SCALA_VERSION=2.12 \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc \
     GPG_KEY=BB137807CEFBE7DD2616556710B12A1F89C115E8
 
 # Prepare environment
@@ -54,11 +54,6 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
-
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-# Not all mirrors have the .asc files
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
-    FLINK_ASC_URL=https://www.apache.org/dist/${FLINK_URL_FILE_PATH}.asc
 
 # Install Flink
 RUN set -ex; \

--- a/1.9/scala_2.11-debian/Dockerfile
+++ b/1.9/scala_2.11-debian/Dockerfile
@@ -46,7 +46,8 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz.asc \
-    GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300
+    GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300 \
+    SKIP_GPG=false
 
 # Prepare environment
 ENV FLINK_HOME=/opt/flink
@@ -58,19 +59,21 @@ WORKDIR $FLINK_HOME
 # Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
-  wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
   \
-  export GNUPGHOME="$(mktemp -d)"; \
-  for server in ha.pool.sks-keyservers.net $(shuf -e \
-                          hkp://p80.pool.sks-keyservers.net:80 \
-                          keyserver.ubuntu.com \
-                          hkp://keyserver.ubuntu.com:80 \
-                          pgp.mit.edu) ; do \
-      gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
-  done && \
-  gpg --batch --verify flink.tgz.asc flink.tgz; \
-  gpgconf --kill all; \
-  rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  if [ "$SKIP_GPG" = "false" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/1.9/scala_2.11-debian/Dockerfile
+++ b/1.9/scala_2.11-debian/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_VERSION=1.9.3 \
-    SCALA_VERSION=2.11 \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz.asc \
     GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300
 
 # Prepare environment
@@ -54,11 +54,6 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
-
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-# Not all mirrors have the .asc files
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
-    FLINK_ASC_URL=https://www.apache.org/dist/${FLINK_URL_FILE_PATH}.asc
 
 # Install Flink
 RUN set -ex; \

--- a/1.9/scala_2.12-debian/Dockerfile
+++ b/1.9/scala_2.12-debian/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_VERSION=1.9.3 \
-    SCALA_VERSION=2.12 \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz.asc \
     GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300
 
 # Prepare environment
@@ -54,11 +54,6 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
-
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-# Not all mirrors have the .asc files
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
-    FLINK_ASC_URL=https://www.apache.org/dist/${FLINK_URL_FILE_PATH}.asc
 
 # Install Flink
 RUN set -ex; \

--- a/1.9/scala_2.12-debian/Dockerfile
+++ b/1.9/scala_2.12-debian/Dockerfile
@@ -46,7 +46,8 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz.asc \
-    GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300
+    GPG_KEY=6B6291A8502BA8F0913AE04DDEB95B05BF075300 \
+    SKIP_GPG=false
 
 # Prepare environment
 ENV FLINK_HOME=/opt/flink
@@ -58,19 +59,21 @@ WORKDIR $FLINK_HOME
 # Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
-  wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
   \
-  export GNUPGHOME="$(mktemp -d)"; \
-  for server in ha.pool.sks-keyservers.net $(shuf -e \
-                          hkp://p80.pool.sks-keyservers.net:80 \
-                          keyserver.ubuntu.com \
-                          hkp://keyserver.ubuntu.com:80 \
-                          pgp.mit.edu) ; do \
-      gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
-  done && \
-  gpg --batch --verify flink.tgz.asc flink.tgz; \
-  gpgconf --kill all; \
-  rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  if [ "$SKIP_GPG" = "false" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -46,7 +46,8 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=%%BINARY_DOWNLOAD_URL%% \
     FLINK_ASC_URL=%%ASC_DOWNLOAD_URL%% \
-    GPG_KEY=%%GPG_KEY%%
+    GPG_KEY=%%GPG_KEY%% \
+    CHECK_GPG=%%CHECK_GPG%%
 
 # Prepare environment
 ENV FLINK_HOME=/opt/flink
@@ -58,19 +59,21 @@ WORKDIR $FLINK_HOME
 # Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
-  wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
   \
-  export GNUPGHOME="$(mktemp -d)"; \
-  for server in ha.pool.sks-keyservers.net $(shuf -e \
-                          hkp://p80.pool.sks-keyservers.net:80 \
-                          keyserver.ubuntu.com \
-                          hkp://keyserver.ubuntu.com:80 \
-                          pgp.mit.edu) ; do \
-      gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
-  done && \
-  gpg --batch --verify flink.tgz.asc flink.tgz; \
-  gpgconf --kill all; \
-  rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  if [ "$CHECK_GPG" = "true" ]; then \
+    wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    for server in ha.pool.sks-keyservers.net $(shuf -e \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys "$GPG_KEY" && break || : ; \
+    done && \
+    gpg --batch --verify flink.tgz.asc flink.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" flink.tgz.asc; \
+  fi; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_VERSION=%%FLINK_VERSION%% \
-    SCALA_VERSION=%%SCALA_VERSION%% \
+ENV FLINK_TGZ_URL=%%BINARY_DOWNLOAD_URL%% \
+    FLINK_ASC_URL=%%ASC_DOWNLOAD_URL%% \
     GPG_KEY=%%GPG_KEY%%
 
 # Prepare environment
@@ -54,11 +54,6 @@ ENV PATH=$FLINK_HOME/bin:$PATH
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
-
-ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
-# Not all mirrors have the .asc files
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
-    FLINK_ASC_URL=https://www.apache.org/dist/${FLINK_URL_FILE_PATH}.asc
 
 # Install Flink
 RUN set -ex; \

--- a/add-custom.sh
+++ b/add-custom.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+# Use this script to build the Dockerfiles against an arbitrary
+# Flink distribution.
+# This is exlusively for development purposes.
+
+source "$(dirname "$0")"/common.sh
+
+function usage() {
+    echo >&2 "usage: $0 -u binary-download-url [-n name]"
+}
+
+binary_download_url=
+name=custom
+
+while getopts u:n:h arg; do
+  case "$arg" in
+    u)
+      binary_download_url=$OPTARG
+      ;;
+    n)
+      name=$OPTARG
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${binary_download_url}" ]; then
+    usage
+    exit 1
+fi
+
+mkdir -p "dev"
+
+echo -n >&2 "Generating Dockerfiles..."
+for source_variant in "${SOURCE_VARIANTS[@]}"; do
+  dir="dev/${name}-${source_variant}"
+  rm -rf "${dir}"
+
+  generate "${dir}" "${binary_download_url}" "" "" false ${source_variant}
+done
+echo >&2 " done."

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# Defaults, can vary between versions
+export SOURCE_VARIANTS=( debian )
+
+function generate() {
+    dir=$1
+    binary_download_url=$2
+    asc_download_url=$3
+    gpg_key=$4
+    check_gpg=$5
+    source_variant=$6
+
+    mkdir "$dir"
+    cp docker-entrypoint.sh "$dir/docker-entrypoint.sh"
+
+    # '&' has special semantics in sed replacement patterns
+    escaped_binary_download_url=$(echo "$binary_download_url" | sed 's/&/\\\&/')
+
+    sed \
+        -e "s,%%BINARY_DOWNLOAD_URL%%,${escaped_binary_download_url}," \
+        -e "s,%%ASC_DOWNLOAD_URL%%,$asc_download_url," \
+        -e "s/%%GPG_KEY%%/$gpg_key/" \
+        -e "s/%%CHECK_GPG%%/${check_gpg}/" \
+        "Dockerfile-$source_variant.template" > "$dir/Dockerfile"
+}


### PR DESCRIPTION
Adds a hook into `add-version.sh` to generate dockerfiles that download the distribution from a configurable URL. Since these likely won't match any GPG signature (as is the case for our nightly snapshots) this check will be skipped.

This required that we pass the URLs directly into the `Dockerfile`, instead of having it generate them from the flink/scala versions.  A new `GPG_SKIP` flag controls whether the signature should be verified.