### PR TITLE
[FLINK-17164] Add job-cluster support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .*.swp
 .idea
 dev
+*.iml
+testing/docker-test-job/target

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 os: linux
 dist: bionic
-language: shell
+language: java
+jdk: "openjdk8"
+
+cache:
+  directories:
+    - $HOME/.m2
 
 services:
 - docker

--- a/testing/docker-test-job/pom.xml
+++ b/testing/docker-test-job/pom.xml
@@ -1,0 +1,75 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.flink</groupId>
+	<artifactId>docker-test-job</artifactId>
+	<version>1.0</version>
+	<packaging>jar</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<flink.version>1.9.0</flink.version>
+		<java.version>1.8</java.version>
+		<scala.binary.version>2.11</scala.binary.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+
+			<!-- Java Compiler -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/testing/docker-test-job/src/main/java/org/apache/flink/StreamingJob.java
+++ b/testing/docker-test-job/src/main/java/org/apache/flink/StreamingJob.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+public class StreamingJob {
+
+	public static void main(String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.addSource(new InfiniteSource()).map(x -> x);
+		env.execute();
+	}
+
+	private static final class InfiniteSource implements SourceFunction<Integer> {
+
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceContext<Integer> ctx) throws Exception {
+			while (running) {
+				Thread.sleep(20);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+}

--- a/testing/run_travis_tests.sh
+++ b/testing/run_travis_tests.sh
@@ -11,14 +11,6 @@ fi
 
 BRANCH="$TRAVIS_BRANCH"
 
-if [ -n "$IS_PULL_REQUEST" ]; then
-  changed_files="$(git diff --name-only $BRANCH...HEAD)"
-
-  echo "Changed files in this pull request:"
-  echo "${changed_files}"
-  echo
-fi
-
 ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.11-SNAPSHOT-bin-hadoop2.tgz"
 
 if [ -z "$IS_PULL_REQUEST" ] && [ "$BRANCH" = "dev-master" ]; then


### PR DESCRIPTION
Adds support for job-clusters.

This PR is also relevant for 1.10, but the commits would be identical.

A job-cluster can be started by passing standalone-job to docker-entrypoint.sh. User artifacts (i.e., the job jar to run) can be passed via the USER_ARTIFACTS environment variable as a list of files/directories, separated with semi-colons (;). This will usually point to some mounted volume.
The script then copies all files into the usrlib directory of the distribution.

The vast majority of this PR is concerned with testing. Since a job-cluster cannot be started without a job to run I added a maven project containing a trivial streaming job that runs infinitely.
The jar is built on CI before the tests are run and provided to the jobmanager as described above.

This PR also removes the diff generation from the testing scripts, which printed the names of all modified names. It doesn't work as is since we no longer compare against the master branch, and I do not consider it valuable enough to invest additional time into fixing it.