### PR TITLE
[FLINK-14241][test]Add arm64 support for docker e2e test -- work in progress

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -15,6 +15,7 @@ function generateDockerfile {
     java_version=$6
     source_variant=$7
 
+    # TODO: Remove this aarch64 condition once all required docker images support arm64 originally.
     if [[ `uname -i` == 'aarch64' ]]; then
         from_docker_image="arm64v8\/openjdk:${java_version}-jre"
     else

--- a/generator.sh
+++ b/generator.sh
@@ -16,7 +16,7 @@ function generateDockerfile {
     source_variant=$7
 
     if [[ `uname -i` == 'aarch64' ]]; then
-        from_docker_image="arm64v8/openjdk:${java_version}-jre"
+        from_docker_image="arm64v8\/openjdk:${java_version}-jre"
     else
         from_docker_image="openjdk:${java_version}-jre"
     fi

--- a/generator.sh
+++ b/generator.sh
@@ -15,7 +15,11 @@ function generateDockerfile {
     java_version=$6
     source_variant=$7
 
-    from_docker_image="openjdk:${java_version}-jre"
+    if [[ `uname -i` == 'aarch64' ]]; then
+        from_docker_image="arm64v8/openjdk:${java_version}-jre"
+    else
+        from_docker_image="openjdk:${java_version}-jre"
+    fi
 
     cp docker-entrypoint.sh "$dir/docker-entrypoint.sh"
 


### PR DESCRIPTION
The docker image `openjdk:8-jre` only works for amd64.

When running  test on arm64, use `arm64v8/openjdk:8-jre` instead.