### PR TITLE
[hotfix] Replace forbidden latest-javaX with javaX

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -71,7 +71,7 @@ function generateReleaseMetadata {
         # we are generating the image for the latest scala version, add:
         # "1.2.0-java11"
         # "1.2-java11"
-        # "latest-java11"
+        # "java11"
         tags="$tags, ${flink_version}${java_suffix}, ${flink_release}${java_suffix}, java${java_version}"
 
         if [[ "$java_version" == "$DEFAULT_JAVA" ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -72,7 +72,7 @@ function generateReleaseMetadata {
         # "1.2.0-java11"
         # "1.2-java11"
         # "latest-java11"
-        tags="$tags, ${flink_version}${java_suffix}, ${flink_release}${java_suffix}, latest${java_suffix}"
+        tags="$tags, ${flink_version}${java_suffix}, ${flink_release}${java_suffix}, java${java_version}"
 
         if [[ "$java_version" == "$DEFAULT_JAVA" ]]; then
             # we are generating the image for the default java version, add tags w/o java tag:


### PR DESCRIPTION
The PR adding the release was rejected by their CI because of this: https://github.com/docker-library/official-images/pull/8459