### PR TITLE
[FLINK-20532] Use prope 'sed' in updated docker image + extend regex …

### DIFF
--- a/generate-stackbrew-library-docker.sh
+++ b/generate-stackbrew-library-docker.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# How to recreate below docker image
+# 
+# $ cat Dockerfile
+# FROM ubuntu:16.04
+# RUN apt-get update ; apt-get install -y git bash
+# 
+# $ docker build -t rmetzger/git-and-bash:latest .
+# $ docker push rmetzger/git-and-bash:latest
+#
+
 exec docker run --rm \
     --volume "${PWD}:/build:ro" \
     rmetzger/git-and-bash:latest \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -47,7 +47,7 @@ pruneTags() {
     else
         # remove "latest" and any "scala_" tag, unless it is the latest version
         # the "scala_" tag has a similar semantic as the "latest" tag in docker registries. 
-        echo $tags | sed -E 's|, (scala\|latest)[-_.[:alnum:]]*||g'
+        echo $tags | sed -E 's|, (scala\|latest\|java[0-9]{1,2})[-_.[:alnum:]]*||g'
     fi
 }
 


### PR DESCRIPTION
The generated file was incorrect because the regex in the sed command didn't work as expected.
This was caused by using busybox' reduced 'sed'.

I updated the Docker image for building the stackbrew entries