### PR TITLE
[FLINK-20632] Add script to publish docker images to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Apache Flink Docker Images
 ==========================
 
 This repo contains Dockerfiles for building Docker images for Apache Flink, and are used to build
-the "official" [`flink`](https://hub.docker.com/_/flink) images hosted on Docker Hub.
+the "official" [`flink`](https://hub.docker.com/_/flink) images hosted on Docker Hub (reviewed and build by Docker), as well as the images published on [`apache/flink` DockerHub](https://hub.docker.com/r/apache/flink) (maintained by Flink committers).
 
 These Dockerfiles are maintained by the Apache Flink community, but the Docker community is
 responsible for building and hosting the images on Docker Hub.
@@ -83,7 +83,14 @@ Updating the Dockerfiles involves the following steps:
       https://github.com/apache/flink-docker/commit/5920fd775ca1a8d03ee959d79bceeb5d6e8f35a1)]</sup>
     * Create a pull request against the `master` branch containing this commit.
 
-Once the pull request has been merged, a new manifest should be generated and a pull request opened
+Once the pull request has been merged, we can release the new docker images:
+
+For **publishing to DockerHub: apache/flink** , you need to perform the following steps:
+
+1. Make sure that you are authenticated with your Docker ID, and that your Docker ID has access to `apache/flink`. If not, request access by INFRA (see [also](https://issues.apache.org/jira/browse/INFRA-21276): `docker login -u <username>`.
+2. Generate and upload the new images: `./publish-to-dockerhub.sh`.
+
+For **publishing as an official image**, a new manifest should be generated and a pull request opened
 on the Docker Library [`official-images`](https://github.com/docker-library/official-images) repo.
 
 1. Run `./generate-stackbrew-library.sh` to output the new manifest (see note [below](

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+    git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+    local dir="$1"; shift
+    (
+        cd "$dir"
+        fileCommit \
+            Dockerfile \
+            $(git show HEAD:./Dockerfile | awk '
+                toupper($1) == "COPY" {
+                    for (i = 2; i < NF; i++) {
+                        print $i
+                    }
+                }
+            ')
+    )
+}
+
+# Inputs:
+#  - tags: comma-seprated list of image tags
+#  - latestVersion: latest version
+# Output: comma-separated list of tags with "latest" removed if not latest version
+pruneTags() {
+    local tags=$1
+    local latestVersion=$2
+    if [[ $tags =~ $latestVersion ]]; then
+        # tags contains latest version. keep "latest" tag
+        echo $tags
+    else
+        # remove "latest", any "scala_" or "javaXX" tag, unless it is the latest version
+        # the "scala" / "java" tags have a similar semantic as the "latest" tag in docker registries. 
+        echo $tags | sed -E 's|, (scala\|latest\|java[0-9]{1,2})[-_.[:alnum:]]*||g'
+    fi
+}
+
+extractValue() {
+    local key="$1"
+    local file="$2"
+    local line=$(cat $file | grep "$key:")
+    echo $line | sed "s/${key}: //g"
+}
+
+# get latest flink version
+latest_version=`ls -1a | grep -E "[0-9]+.[0-9]+" | sort -V -r | head -n 1`


### PR DESCRIPTION
I've test-deployed this to my personal GitHub account: https://github.com/rmetzger/flink/packages/561326/versions (the "Latest Version" annotation is wrong, but we would not link this page prominently anyways)