### PR TITLE
[FLINK-21036] Remove automatic configuration of number of slots

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -135,7 +135,7 @@ elif [ "$1" = "taskmanager" ]; then
 
     echo "Starting Task Manager"
 
-    TASK_MANAGER_NUMBER_OF_TASK_SLOTS=${TASK_MANAGER_NUMBER_OF_TASK_SLOTS:-$(grep -c ^processor /proc/cpuinfo)}
+    TASK_MANAGER_NUMBER_OF_TASK_SLOTS=${TASK_MANAGER_NUMBER_OF_TASK_SLOTS:-1}
 
     set_common_options
     set_config_option taskmanager.numberOfTaskSlots ${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}


### PR DESCRIPTION
Removes an odd special code path for taskmanagers started in docker.