### PR TITLE
Go back to Flink 1.12.0

### DIFF
--- a/1.12/scala_2.11-java11-debian/Dockerfile
+++ b/1.12/scala_2.11-java11-debian/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.asc \
-    GPG_KEY=F8E419AA0B60C28879E876859DFF40967ABFC5A4 \
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.11.tgz \
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.11.tgz.asc \
+    GPG_KEY=43CE299BC305AFF8B912AA95183F6944D9839159 \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.12/scala_2.11-java11-debian/release.metadata
+++ b/1.12/scala_2.11-java11-debian/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.12.1-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
+Tags: 1.12.0-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
 Architectures: amd64

--- a/1.12/scala_2.11-java8-debian/Dockerfile
+++ b/1.12/scala_2.11-java8-debian/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.asc \
-    GPG_KEY=F8E419AA0B60C28879E876859DFF40967ABFC5A4 \
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.11.tgz \
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.11.tgz.asc \
+    GPG_KEY=43CE299BC305AFF8B912AA95183F6944D9839159 \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.12/scala_2.11-java8-debian/release.metadata
+++ b/1.12/scala_2.11-java8-debian/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.12.1-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.1-scala_2.11, 1.12-scala_2.11, scala_2.11
+Tags: 1.12.0-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.0-scala_2.11, 1.12-scala_2.11, scala_2.11
 Architectures: amd64

--- a/1.12/scala_2.12-java11-debian/Dockerfile
+++ b/1.12/scala_2.12-java11-debian/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.asc \
-    GPG_KEY=F8E419AA0B60C28879E876859DFF40967ABFC5A4 \
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.12.tgz.asc \
+    GPG_KEY=43CE299BC305AFF8B912AA95183F6944D9839159 \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.12/scala_2.12-java11-debian/release.metadata
+++ b/1.12/scala_2.12-java11-debian/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.12.1-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.1-java11, 1.12-java11, java11
+Tags: 1.12.0-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.0-java11, 1.12-java11, java11
 Architectures: amd64

--- a/1.12/scala_2.12-java8-debian/Dockerfile
+++ b/1.12/scala_2.12-java8-debian/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.asc \
-    GPG_KEY=F8E419AA0B60C28879E876859DFF40967ABFC5A4 \
+ENV FLINK_TGZ_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-bin-scala_2.12.tgz.asc \
+    GPG_KEY=43CE299BC305AFF8B912AA95183F6944D9839159 \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.12/scala_2.12-java8-debian/release.metadata
+++ b/1.12/scala_2.12-java8-debian/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.12.1-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.1-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.1-java8, 1.12-java8, java8, 1.12.1, 1.12, latest
+Tags: 1.12.0-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.0-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.0-java8, 1.12-java8, java8, 1.12.0, 1.12, latest
 Architectures: amd64


### PR DESCRIPTION
Temporarily roll master back to 1.12.0, so that we can generate the stackbrew file for 1.12.0.
Once 1.12.0 is on docker hub, we can release 1.12.1 there, so that the latest tag is correct.

Here's the current stackbrew output:

\# this file is generated via https://github.com/apache/flink-docker/blob/f47f4a2e257279c4c28667e3ceff12bc5eb70afb/generate-stackbrew-library.sh

Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
             Ismaël Mejía <iemejia@gmail.com> (@iemejia)
GitRepo: https://github.com/apache/flink-docker.git

Tags: 1.11.3-scala_2.11-java11, 1.11-scala_2.11-java11
Architectures: amd64
GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
Directory: ./1.11/scala_2.11-java11-debian

Tags: 1.11.3-scala_2.11-java8, 1.11-scala_2.11-java8, 1.11.3-scala_2.11, 1.11-scala_2.11
Architectures: amd64
GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
Directory: ./1.11/scala_2.11-java8-debian

Tags: 1.11.3-scala_2.12-java11, 1.11-scala_2.12-java11, 1.11.3-java11, 1.11-java11
Architectures: amd64
GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
Directory: ./1.11/scala_2.12-java11-debian

Tags: 1.11.3-scala_2.12-java8, 1.11-scala_2.12-java8, 1.11.3-scala_2.12, 1.11-scala_2.12, 1.11.3-java8, 1.11-java8, 1.11.3, 1.11
Architectures: amd64
GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
Directory: ./1.11/scala_2.12-java8-debian

Tags: 1.12.0-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
Architectures: amd64
GitCommit: d2ff00e0176e09cdbbde76412026054016a8551c
Directory: ./1.12/scala_2.11-java11-debian

Tags: 1.12.0-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.0-scala_2.11, 1.12-scala_2.11, scala_2.11
Architectures: amd64
GitCommit: d2ff00e0176e09cdbbde76412026054016a8551c
Directory: ./1.12/scala_2.11-java8-debian

Tags: 1.12.0-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.0-java11, 1.12-java11, java11
Architectures: amd64
GitCommit: d2ff00e0176e09cdbbde76412026054016a8551c
Directory: ./1.12/scala_2.12-java11-debian

Tags: 1.12.0-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.0-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.0-java8, 1.12-java8, java8, 1.12.0, 1.12, latest
Architectures: amd64
GitCommit: d2ff00e0176e09cdbbde76412026054016a8551c
Directory: ./1.12/scala_2.12-java8-debian