### PR TITLE
[FLINK-21554] Remove the magical classpath setting stuff in docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,10 +134,5 @@ fi
 
 args=("${args[@]}")
 
-# Set the Flink related environments
-export _FLINK_HOME_DETERMINED=true
-. $FLINK_HOME/bin/config.sh
-export FLINK_CLASSPATH="`constructFlinkClassPath`:$INTERNAL_HADOOP_CLASSPATHS"
-
 # Running command in pass-through mode
 exec $(drop_privs_cmd) "${args[@]}"


### PR DESCRIPTION
After FLINK-21128 is done, we could remove the magical classpath setting stuff in docker-entrypoint.sh.

 
```
# Set the Flink related environments
export _FLINK_HOME_DETERMINED=true
. $FLINK_HOME/bin/config.sh
export FLINK_CLASSPATH="`constructFlinkClassPath`:$INTERNAL_HADOOP_CLASSPATHS"
```

This is a promised change in https://github.com/docker-library/official-images/pull/9249#issuecomment-768561251.