### PR TITLE
[FLINK-24474] Bind Rest endpoint addresses to 0.0.0.0 by default

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -80,6 +80,10 @@ RUN set -ex; \
   \
   chown -R flink:flink .;
 
+# Replace default REST endpoint bind address to use the container's network interface
+RUN sed -i 's/rest.address: localhost/rest.address: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml
+RUN sed -i 's/rest.bind-address: localhost/rest.bind-address: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml
+
 # Configure container
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
With FLINK-24474, we are going to bind the REST endpoint to `localhost` by default as a security precaution. This PR adds to the dockerfile to update this default setting to bind to `0.0.0.0`, so that Flink binds to a network interface within the container, so that it can communicate with the Docker network layer. This is done within the Dockerfile and not the docker-entrypoint.sh due to FLINK-21383.