### PR TITLE
[FLINK-24474] reset taskmanager.host

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -85,6 +85,7 @@ RUN sed -i 's/rest.address: localhost/rest.address: 0.0.0.0/g' $FLINK_HOME/conf/
 RUN sed -i 's/rest.bind-address: localhost/rest.bind-address: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml
 RUN sed -i 's/jobmanager.bind-host: localhost/jobmanager.bind-host: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml
 RUN sed -i 's/taskmanager.bind-host: localhost/taskmanager.bind-host: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml
+RUN sed -i '/taskmanager.host: localhost/d' $FLINK_HOME/conf/flink-conf.yaml
 
 # Configure container
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
Reset `taskmanager.host` setting, as we add a default setting in [FLINK-24474](https://issues.apache.org/jira/browse/FLINK-24474) that is not applicable for docker containers.