### PR TITLE
[FLINK-28057] Fix LD_PRELOAD on ARM images

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,7 +91,20 @@ prepare_configuration() {
 
 maybe_enable_jemalloc() {
     if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
-        export LD_PRELOAD=$LD_PRELOAD:/usr/lib/x86_64-linux-gnu/libjemalloc.so
+        JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+        JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+        if [ -f "$JEMALLOC_PATH" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_PATH
+        elif [ -f "$JEMALLOC_FALLBACK" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_FALLBACK
+        else
+            if [ "$JEMALLOC_PATH" = "$JEMALLOC_FALLBACK" ]; then
+                MSG_PATH=$JEMALLOC_PATH
+            else
+                MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
+            fi
+            echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
+        fi
     fi
 }
 

--- a/testing/bin/docker-entrypoint.sh
+++ b/testing/bin/docker-entrypoint.sh
@@ -27,11 +27,19 @@ originalLdPreloadSetting=$3
 jemallocDisabled=$4
 
 if [ "$jemallocDisabled" == "true" ] && ! [ "$originalLdPreloadSetting" == "$LD_PRELOAD" ]; then
-    echo "jemalloc was not disabled; expected LD_PRELOAD to be '$originalLdPreloadSetting' but was '$LD_PRELOAD'"
+    echo "jemalloc was disabled; expected LD_PRELOAD to be '$originalLdPreloadSetting' but was '$LD_PRELOAD'"
     exit 1
 fi
 
+# We expect jemalloc to be available in any of these paths
+JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+
 if [ "$jemallocDisabled" == "false" ] && [ "$originalLdPreloadSetting" == "$LD_PRELOAD" ]; then
-    echo "jemalloc was disabled; expected LD_PRELOAD to be different than '$originalLdPreloadSetting'."
+    if [ ! -f "$JEMALLOC_PATH" ] && [ ! -f "$JEMALLOC_FALLBACK" ]; then
+      echo "jemalloc was enabled but it was not found in the system. LD_PRELOAD is unchanged and glibc will be used instead."
+      exit 0
+    fi
+    echo "jemalloc was enabled; expected LD_PRELOAD to be different than '$originalLdPreloadSetting'."
     exit 1
 fi


### PR DESCRIPTION
This fixes an error that prevents jemalloc from being loaded on ARM images:
```
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libjemalloc.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```