### PR TITLE
Update key for 1.15.1 to use full fingerprint

### DIFF
--- a/1.15/scala_2.12-java11-debian/Dockerfile
+++ b/1.15/scala_2.12-java11-debian/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.15.1/flink-1.15.1-bin-scala_2.12.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.15.1/flink-1.15.1-bin-scala_2.12.tgz.asc \
-    GPG_KEY=3EE012FEE982F098 \
+    GPG_KEY=7D660377995CA7A5AFEBA79A3EE012FEE982F098 \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.15/scala_2.12-java8-debian/Dockerfile
+++ b/1.15/scala_2.12-java8-debian/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex; \
 # Configure Flink version
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.15.1/flink-1.15.1-bin-scala_2.12.tgz \
     FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.15.1/flink-1.15.1-bin-scala_2.12.tgz.asc \
-    GPG_KEY=3EE012FEE982F098 \
+    GPG_KEY=7D660377995CA7A5AFEBA79A3EE012FEE982F098 \
     CHECK_GPG=true
 
 # Prepare environment


### PR DESCRIPTION
@xintongsong This is a companion to https://github.com/apache/flink-docker/pull/122.
