### PR TITLE
[FLINK-27671] Add arm support for snapshot docker images

### DIFF
--- a/.github/workflows/docker-bake.hcl
+++ b/.github/workflows/docker-bake.hcl
@@ -1,0 +1,38 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+target "docker-metadata-action" {}
+
+variable TAG {
+    default = "latest-snapshot"
+}
+
+variable DOCKER_FILE {
+    default = "Dockerfile"
+}
+
+target "bake-platform" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "${DOCKER_FILE}"
+  context = "./"
+  tags = ["${TAG}"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64/v8",
+  ]
+}


### PR DESCRIPTION
Just the docker bake file, GHA is on the master branch.