### PR TITLE
[ADD-SYMLINKS] Add symlinks for FLINK_VERSION to FLINK_RELEASE jars

### DIFF
--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -44,7 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=%%BINARY_DOWNLOAD_URL%% \
+ENV FLINK_RELEASE=%%FLINK_RELEASE%% \
+    FLINK_VERSION=%%FLINK_VERSION%% \
+    FLINK_TGZ_URL=%%BINARY_DOWNLOAD_URL%% \
     FLINK_ASC_URL=%%ASC_DOWNLOAD_URL%% \
     GPG_KEY=%%GPG_KEY%% \
     CHECK_GPG=%%CHECK_GPG%%
@@ -85,7 +87,18 @@ RUN set -ex; \
   sed -i 's/rest.bind-address: localhost/rest.bind-address: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml; \
   sed -i 's/jobmanager.bind-host: localhost/jobmanager.bind-host: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml; \
   sed -i 's/taskmanager.bind-host: localhost/taskmanager.bind-host: 0.0.0.0/g' $FLINK_HOME/conf/flink-conf.yaml; \
-  sed -i '/taskmanager.host: localhost/d' $FLINK_HOME/conf/flink-conf.yaml;
+  sed -i '/taskmanager.host: localhost/d' $FLINK_HOME/conf/flink-conf.yaml; \
+  \
+  # if FLINK_RELEASE != FLINK_VERSION \
+  # Symlink FLINK_RELEASE (e.g. 1.16) jars to FLINK_VERSION (e.g. 1.16.2) jars \
+  # e.g. flink-s3-fs-presto-1.16.jar -> flink-s3-fs-presto-1.16.2.jar \
+  if [ "$FLINK_RELEASE" != "$FLINK_VERSION" ]; then \
+    for f in `find . -name *$FLINK_VERSION.jar` \
+    do \
+      jar=`basename $f`
+      ln -s $jar ${f/$FLINK_VERSION/$FLINK_RELEASE}
+    done \
+  fi
 
 # Configure container
 COPY docker-entrypoint.sh /

--- a/add-custom.sh
+++ b/add-custom.sh
@@ -48,6 +48,6 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
   dir="dev/${name}-${source_variant}"
   rm -rf "${dir}"
   mkdir "$dir"
-  generateDockerfile "${dir}" "${binary_download_url}" "" "" false ${java_version} ${source_variant}
+  generateDockerfile "${dir}" ${flink_release} ${flink_version} "" false ${java_version} ${scala_version} ${source_variant}
 done
 echo >&2 " done."

--- a/add-custom.sh
+++ b/add-custom.sh
@@ -48,6 +48,6 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
   dir="dev/${name}-${source_variant}"
   rm -rf "${dir}"
   mkdir "$dir"
-  generateDockerfile "${dir}" ${flink_release} ${flink_version} "" false ${java_version} ${scala_version} ${source_variant}
+  generateDockerfile "${dir}" ${flink_release} "" "" false ${java_version} ${scala_version} ${source_variant}
 done
 echo >&2 " done."

--- a/add-version.sh
+++ b/add-version.sh
@@ -120,12 +120,6 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
         for java_version in "${java_versions[@]}"; do
             dir="$flink_release/scala_${scala_version}-java${java_version}-${source_variant}"
 
-            flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz
-
-            flink_tgz_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
-            # Not all mirrors have the .asc files
-            flink_asc_url=https://www.apache.org/dist/${flink_url_file_path}.asc
-
             mkdir "$dir"
             generateDockerfile "${dir}" "${flink_release}" "${flink_version}" ${gpg_key} true ${java_version} ${source_variant}
             generateReleaseMetadata "${dir}" ${flink_release} ${flink_version} ${scala_version} ${java_version} ${source_variant}

--- a/add-version.sh
+++ b/add-version.sh
@@ -127,7 +127,7 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
             flink_asc_url=https://www.apache.org/dist/${flink_url_file_path}.asc
 
             mkdir "$dir"
-            generateDockerfile "${dir}" "${flink_tgz_url}" "${flink_asc_url}" ${gpg_key} true ${java_version} ${source_variant}
+            generateDockerfile "${dir}" "${flink_release}" "${flink_version}" ${gpg_key} true ${java_version} ${source_variant}
             generateReleaseMetadata "${dir}" ${flink_release} ${flink_version} ${scala_version} ${java_version} ${source_variant}
         done
     done

--- a/add-version.sh
+++ b/add-version.sh
@@ -121,7 +121,7 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
             dir="$flink_release/scala_${scala_version}-java${java_version}-${source_variant}"
 
             mkdir "$dir"
-            generateDockerfile "${dir}" "${flink_release}" "${flink_version}" ${gpg_key} true ${java_version} ${source_variant}
+            generateDockerfile "${dir}" "${flink_release}" "${flink_version}" ${gpg_key} true ${java_version} ${scala_version} ${source_variant}
             generateReleaseMetadata "${dir}" ${flink_release} ${flink_version} ${scala_version} ${java_version} ${source_variant}
         done
     done

--- a/generator.sh
+++ b/generator.sh
@@ -8,12 +8,17 @@ export DEFAULT_JAVA="11"
 function generateDockerfile {
     # define variables
     dir=$1
-    binary_download_url=$2
-    asc_download_url=$3
+    flink_release=$2
+    flink_version=$3
     gpg_key=$4
     check_gpg=$5
     java_version=$6
     source_variant=$7
+
+    flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz
+    flink_tgz_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
+    # Not all mirrors have the .asc files
+    flink_asc_url=https://www.apache.org/dist/${flink_url_file_path}.asc
 
     from_docker_image="eclipse-temurin:${java_version}-jre-jammy"
 
@@ -24,6 +29,9 @@ function generateDockerfile {
 
     # generate Dockerfile
     sed \
+        -e "s,%%FLINK_RELEASE%%,${flink_release}," \
+        -e "s,%%FLINK_VERSION%%,${flink_version}," \
+        -e "s,%%BINARY_DOWNLOAD_URL%%,${escaped_binary_download_url}," \
         -e "s,%%BINARY_DOWNLOAD_URL%%,${escaped_binary_download_url}," \
         -e "s,%%ASC_DOWNLOAD_URL%%,$asc_download_url," \
         -e "s/%%GPG_KEY%%/$gpg_key/" \

--- a/generator.sh
+++ b/generator.sh
@@ -13,7 +13,8 @@ function generateDockerfile {
     gpg_key=$4
     check_gpg=$5
     java_version=$6
-    source_variant=$7
+    scala_version=$6
+    source_variant=$8
 
     flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz
     binary_download_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"

--- a/generator.sh
+++ b/generator.sh
@@ -13,7 +13,7 @@ function generateDockerfile {
     gpg_key=$4
     check_gpg=$5
     java_version=$6
-    scala_version=$6
+    scala_version=$7
     source_variant=$8
 
     flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz

--- a/generator.sh
+++ b/generator.sh
@@ -16,9 +16,9 @@ function generateDockerfile {
     source_variant=$7
 
     flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz
-    flink_tgz_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
+    binary_download_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
     # Not all mirrors have the .asc files
-    flink_asc_url=https://www.apache.org/dist/${flink_url_file_path}.asc
+    asc_download_url=https://www.apache.org/dist/${flink_url_file_path}.asc
 
     from_docker_image="eclipse-temurin:${java_version}-jre-jammy"
 


### PR DESCRIPTION
Hi flink team - we're using the `flink:1.16` base image to deploy many of our flink jobs, but because this image is built on top of a more specific bugfix release (1.16.X), we run into issues where referencing specific jar versions in our deployment configurations (e.g. `flink-libary-1.16.2.jar`) break when the underlying base image bumps the bugfix version number.

This PR provides a fix wherein the FLINK_RELEASE (1.16) is symlinked to the underlying FLINK_VERSION (1.16.2) jars.

```
# e.g. 
> ls opt
....
 flink-python-1.16.jar -> flink-python-1.16.2.jar
....
``` 

This is a similar pattern to the way many linux distros handle sxs installations of versioned libraries. 

In our deployments, we would now use `flink:1.16` docker base image, _and_ reference jars by the `1.16.jar` version, instead of being forced to reference them by a specific bugfix version that occasionally breaks

NOTE: we're aware that we can _also_ use the `flink:1.16.2` base image - but this locks us out of bugfix releases. 

If you like this pattern, I'd be happy to port to the other dev branches as well