### PR TITLE
Update Dockerfiles for 1.16.3 release

### DIFF
--- a/1.16/scala_2.12-java11-ubuntu/Dockerfile
+++ b/1.16/scala_2.12-java11-ubuntu/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz.asc \
-    GPG_KEY=8D56AE6E7082699A4870750EA4E8C4C05EE6861F \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.16.3/flink-1.16.3-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.16.3/flink-1.16.3-bin-scala_2.12.tgz.asc \
+    GPG_KEY=B2D64016B940A7E0B9B72E0D7D0528B28037D8BC \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.16/scala_2.12-java11-ubuntu/release.metadata
+++ b/1.16/scala_2.12-java11-ubuntu/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.16.2-scala_2.12-java11, 1.16-scala_2.12-java11, scala_2.12-java11, 1.16.2-scala_2.12, 1.16-scala_2.12, scala_2.12, 1.16.2-java11, 1.16-java11, java11, 1.16.2, 1.16, latest
+Tags: 1.16.3-scala_2.12-java11, 1.16-scala_2.12-java11, scala_2.12-java11, 1.16.3-scala_2.12, 1.16-scala_2.12, scala_2.12, 1.16.3-java11, 1.16-java11, java11, 1.16.3, 1.16, latest
 Architectures: amd64,arm64v8

--- a/1.16/scala_2.12-java8-ubuntu/Dockerfile
+++ b/1.16/scala_2.12-java8-ubuntu/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.16.2/flink-1.16.2-bin-scala_2.12.tgz.asc \
-    GPG_KEY=8D56AE6E7082699A4870750EA4E8C4C05EE6861F \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.16.3/flink-1.16.3-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.16.3/flink-1.16.3-bin-scala_2.12.tgz.asc \
+    GPG_KEY=B2D64016B940A7E0B9B72E0D7D0528B28037D8BC \
     CHECK_GPG=true
 
 # Prepare environment

--- a/1.16/scala_2.12-java8-ubuntu/release.metadata
+++ b/1.16/scala_2.12-java8-ubuntu/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.16.2-scala_2.12-java8, 1.16-scala_2.12-java8, scala_2.12-java8, 1.16.2-java8, 1.16-java8, java8
+Tags: 1.16.3-scala_2.12-java8, 1.16-scala_2.12-java8, scala_2.12-java8, 1.16.3-java8, 1.16-java8, java8
 Architectures: amd64,arm64v8


### PR DESCRIPTION
GPG key(`B2D64016B940A7E0B9B72E0D7D0528B28037D8BC`) can be found from 1.16.3 vote mail and KEYS[2].

[1] https://lists.apache.org/thread/dxfmt3v5n0xv5r9tjl30ob5d7y5t7pw3
[2] https://dist.apache.org/repos/dist/release/flink/KEYS
