### PR TITLE
[FLINK-33842][docs] Update Dockerfiles for 1.18.1 release

### DIFF
--- a/1.18/scala_2.12-java11-ubuntu/Dockerfile
+++ b/1.18/scala_2.12-java11-ubuntu/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz.asc \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz.asc \
     GPG_KEY=96AE0E32CBE6E0753CE6DF6CB078D1D3253A8D82 \
     CHECK_GPG=true
 

--- a/1.18/scala_2.12-java11-ubuntu/release.metadata
+++ b/1.18/scala_2.12-java11-ubuntu/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.18.0-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.0-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.0-java11, 1.18-java11, java11, 1.18.0, 1.18, latest
+Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.1-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.1-java11, 1.18-java11, java11, 1.18.1, 1.18, latest
 Architectures: amd64,arm64v8

--- a/1.18/scala_2.12-java17-ubuntu/Dockerfile
+++ b/1.18/scala_2.12-java17-ubuntu/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz.asc \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz.asc \
     GPG_KEY=96AE0E32CBE6E0753CE6DF6CB078D1D3253A8D82 \
     CHECK_GPG=true
 

--- a/1.18/scala_2.12-java17-ubuntu/release.metadata
+++ b/1.18/scala_2.12-java17-ubuntu/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.18.0-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.0-java17, 1.18-java17, java17
+Tags: 1.18.1-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.1-java17, 1.18-java17, java17
 Architectures: amd64,arm64v8

--- a/1.18/scala_2.12-java8-ubuntu/Dockerfile
+++ b/1.18/scala_2.12-java8-ubuntu/Dockerfile
@@ -44,8 +44,8 @@ RUN set -ex; \
   gosu nobody true
 
 # Configure Flink version
-ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz \
-    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.0/flink-1.18.0-bin-scala_2.12.tgz.asc \
+ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz \
+    FLINK_ASC_URL=https://www.apache.org/dist/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz.asc \
     GPG_KEY=96AE0E32CBE6E0753CE6DF6CB078D1D3253A8D82 \
     CHECK_GPG=true
 

--- a/1.18/scala_2.12-java8-ubuntu/release.metadata
+++ b/1.18/scala_2.12-java8-ubuntu/release.metadata
@@ -1,2 +1,2 @@
-Tags: 1.18.0-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.0-java8, 1.18-java8, java8
+Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.1-java8, 1.18-java8, java8
 Architectures: amd64,arm64v8


### PR DESCRIPTION
GPG key(96AE0E32CBE6E0753CE6DF6CB078D1D3253A8D82) can be found from 1.18.1 vote mail and KEYS[2].

[1] https://lists.apache.org/thread/zkgh6c9vhk9z3072vqlxxtbvrghllcp8
[2] https://dist.apache.org/repos/dist/release/flink/KEYS