### PR TITLE
[FLINK-34165][1.17] update the apache download url for asc

### DIFF
--- a/add-version.sh
+++ b/add-version.sh
@@ -126,7 +126,7 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
 
             flink_tgz_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
             # Not all mirrors have the .asc files
-            flink_asc_url=https://www.apache.org/dist/${flink_url_file_path}.asc
+            flink_asc_url=https://downloads.apache.org/${flink_url_file_path}.asc
 
             mkdir "$dir"
             generateDockerfile "${dir}" "${flink_tgz_url}" "${flink_asc_url}" ${gpg_key} true ${java_version} ${source_variant}


### PR DESCRIPTION
similar to https://github.com/apache/flink-docker/pull/170 but for dev-1.17