### PR TITLE
[FLINK-34282] Update dev-master point to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Build images"
         run: |
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 8 -n test-java8
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 11 -n test-java11
+          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.20-SNAPSHOT-bin-scala_2.12.tgz" -j 8 -n test-java8
+          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.20-SNAPSHOT-bin-scala_2.12.tgz" -j 11 -n test-java11
       - name: "Test images"
         run: testing/run_tests.sh


### PR DESCRIPTION
As a step for creating flink release-1.9 branch  https://issues.apache.org/jira/browse/FLINK-34282
this pr update dev-master  point to the most recent snapshot version 1.20
