### PR TITLE
[FLINK-34419][docker] Added support of JDK 17 & 21 for Flink 1.18+ 

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -50,21 +50,18 @@ jobs:
             java_version: [8, 11]
             branch: dev-1.17
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.build.branch }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -82,7 +79,7 @@ jobs:
         run: env
 
       - name: Build and push Docker images (supported platforms)
-        uses: docker/bake-action@v1.7.0
+        uses: docker/bake-action@v4
         with:
           files: |
             .github/workflows/docker-bake.hcl

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -36,15 +36,18 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java_version: [8, 11]
         build:
           - flink_version: 1.20-SNAPSHOT
+            java_version: [8, 11, 17, 21]
             branch: dev-master
           - flink_version: 1.19-SNAPSHOT
+            java_version: [8, 11, 17, 21]
             branch: dev-1.19
           - flink_version: 1.18-SNAPSHOT
+            java_version: [8, 11, 17]
             branch: dev-1.18
           - flink_version: 1.17-SNAPSHOT
+            java_version: [8, 11]
             branch: dev-1.17
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +66,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

[[FLINK-34419](https://issues.apache.org/jira/browse/FLINK-34419)]:  Adds support of JDK 17 & 21 for Flink 1.18+ versions in the snapshot builds.