### PR TITLE
[FLINK-34419][docker] Add tests for JDK 17 & 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,21 @@ name: "CI"
 
 on: [push, pull_request]
 
+env:
+  FLINK_TAR_URL: "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz"
+
 jobs:
   ci:
+    name: CI using JDK ${{ matrix.java_version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [ 8, 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: "Build images"
         run: |
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 8 -n test-java8
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 11 -n test-java11
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 17 -n test-java17
-          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 21 -n test-java21
+          ./add-custom.sh -u "$FLINK_TAR_URL" -j ${{ matrix.java_version }} -n "test-java${{ matrix.java_version }}"
       - name: "Test images"
         run: testing/run_tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         java_version: [ 8, 11, 17, 21 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Build images"
         run: |
           ./add-custom.sh -u "$FLINK_TAR_URL" -j ${{ matrix.java_version }} -n "test-java${{ matrix.java_version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,7 @@ jobs:
         run: |
           ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 8 -n test-java8
           ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 11 -n test-java11
+          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 17 -n test-java17
+          ./add-custom.sh -u "https://s3.amazonaws.com/flink-nightly/flink-1.19-SNAPSHOT-bin-scala_2.12.tgz" -j 21 -n test-java21
       - name: "Test images"
         run: testing/run_tests.sh


### PR DESCRIPTION

[[FLINK-34419](https://issues.apache.org/jira/browse/FLINK-34419)]: Updated tests to use JDK 17 and 21 versions in `dev-1.19`.