### PR TITLE
Add GPG key for 1.19.0 release

### DIFF
--- a/add-version.sh
+++ b/add-version.sh
@@ -102,6 +102,8 @@ elif [ "$flink_version" = "1.17.0" ]; then
     gpg_key="A1BD477F79D036D2C30CA7DBCA8AEEC2F6EB040B"
 elif [ "$flink_version" = "1.18.0" ]; then
     gpg_key="96AE0E32CBE6E0753CE6DF6CB078D1D3253A8D82"
+elif [ "$flink_version" = "1.19.0" ]; then
+    gpg_key="028B6605F51BC296B56A5042E57D30ABEE75CA06"
 else
     error "Missing GPG key ID for this release"
 fi


### PR DESCRIPTION
This is a backport pr of #185 to sync gpg key from dev-master to dev-1.19.