### PR TITLE
[hotfix] Refactoring docker-entrypoint.sh to Use Arrays for Configuration Parameters Instead of Eval and String Concatenation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,19 +65,19 @@ set_config_options() {
     local bin_dir="$FLINK_HOME/bin"
     local lib_dir="$FLINK_HOME/lib"
 
-    local config_params=""
+    local config_params=()
 
     while [ $# -gt 0 ]; do
         local key="$1"
         local value="$2"
 
-        config_params+=" -D${key}=${value}"
+        config_params+=("-D${key}=${value}")
 
         shift 2
     done
 
-    if [ ! -z "${config_params}" ]; then
-        eval "${config_parser_script} ${config_dir} ${bin_dir} ${lib_dir} ${config_params}"
+    if [ "${#config_params[@]}" -gt 0 ]; then
+        "${config_parser_script}" "${config_dir}" "${bin_dir}" "${lib_dir}" "${config_params[@]}"
     fi
 }
 


### PR DESCRIPTION
Refactor the docker-entrypoint.sh script as per the suggestions in the comments of https://github.com/docker-library/official-images/pull/16430#issuecomment-2005337882