### PR TITLE
[FLINK-34746] Switching to the Apache CDN for Dockerfile

### DIFF
--- a/add-version.sh
+++ b/add-version.sh
@@ -124,7 +124,7 @@ for source_variant in "${SOURCE_VARIANTS[@]}"; do
 
             flink_url_file_path=flink/flink-${flink_version}/flink-${flink_version}-bin-scala_${scala_version}.tgz
 
-            flink_tgz_url="https://www.apache.org/dyn/closer.cgi?action=download&filename=${flink_url_file_path}"
+            flink_tgz_url="https://dlcdn.apache.org/${flink_url_file_path}"
             # Not all mirrors have the .asc files
             flink_asc_url=https://downloads.apache.org/${flink_url_file_path}.asc
 


### PR DESCRIPTION
Backport of https://github.com/apache/flink-docker/pull/190
