### PR TITLE
Update GPG key for 1.19.1 release to full key ID

### DIFF
--- a/add-version.sh
+++ b/add-version.sh
@@ -105,7 +105,7 @@ elif [ "$flink_version" = "1.18.0" ]; then
 elif [ "$flink_version" = "1.19.0" ]; then
     gpg_key="028B6605F51BC296B56A5042E57D30ABEE75CA06"
 elif [ "$flink_version" = "1.19.1" ]; then
-    gpg_key="B78A5EA1"
+    gpg_key="6378E37EB3AAEA188B9CB0D396C2914BB78A5EA1"
 else
     error "Missing GPG key ID for this release"
 fi


### PR DESCRIPTION
Update GPG key for 1.19.1 release to full key ID

Verified that lookup on pgp works
https://keyserver.ubuntu.com/pks/lookup?search=6378E37EB3AAEA188B9CB0D396C2914BB78A5EA1&fingerprint=on&op=index