### PR TITLE
Align entrypoint with what was used for 1.19.1

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,19 +65,19 @@ set_config_options() {
     local bin_dir="$FLINK_HOME/bin"
     local lib_dir="$FLINK_HOME/lib"
 
-    local config_params=""
+    local config_params=()
 
     while [ $# -gt 0 ]; do
         local key="$1"
         local value="$2"
 
-        config_params+=" -D${key}=${value}"
+        config_params+=("-D${key}=${value}")
 
         shift 2
     done
 
-    if [ ! -z "${config_params}" ]; then
-        eval "${config_parser_script} ${config_dir} ${bin_dir} ${lib_dir} ${config_params}"
+    if [ "${#config_params[@]}" -gt 0 ]; then
+        "${config_parser_script}" "${config_dir}" "${bin_dir}" "${lib_dir}" "${config_params[@]}"
     fi
 }
 


### PR DESCRIPTION
1.19.1 release entrypoint seem to have been generated off of 1.20 release branch. This raises questions for publishing in the official-images repo
https://github.com/docker-library/official-images/pull/18452#issuecomment-2657791726
This PR syncs the dev-1.19 entrypoint with what is already out there for the 1.19.1 image