### PR TITLE
[hotfix] re-add jdk11 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 17, 21 ]
+        java_version: [ 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: "Build images"


### PR DESCRIPTION
nightly binary release is built by jdk11 now, we should re-enable jdk11 test.