### PR TITLE
Change base image from jre-jammy to jre-noble for security improvements

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -15,7 +15,7 @@ function generateDockerfile {
     java_version=$6
     source_variant=$7
 
-    from_docker_image="eclipse-temurin:${java_version}-jre-jammy"
+    from_docker_image="eclipse-temurin:${java_version}-jre-noble"
 
     cp docker-entrypoint.sh "$dir/docker-entrypoint.sh"
 


### PR DESCRIPTION
Hello,

We're using official Apache Flink Java images as base images in our project, but our security scans have identified numerous vulnerabilities originating from these base images. We want to continue using official images; however, to do so, we must address these security issues. It appears that the majority of vulnerabilities stem from Ubuntu 22, which is part of the jre-jammy base image. We propose switching to the jre-noble base image to migrate to Ubuntu 24, which contains the latest security fixes.

## What Changed
- Updated `generator.sh` to use `eclipse-temurin:*-jre-noble` instead of `eclipse-temurin:*-jre-jammy`
- This affects all Flink Docker images across all Java versions (8, 11, 17, 21)

## Why
- **Security**: Ubuntu 24.04 LTS (Noble) vs 22.04 LTS (Jammy) = 2 years of additional security patches  
- **Support**: Extended LTS support until 2029 vs 2027
- **Vulnerabilities**: Reduced vulnerability footprint with more recent base packages

## Testing
Locally built and tested `flink:1.20.2-scala_2.12-java17-noble` successfully.

## Impact
This change will update the base image for ALL Flink Docker variants when the next Dockerfiles are generated.