### PR TITLE
[FLINK-38587] Fix docker entrypoint script to preserve spaces in FLINK_PROPERTIES   values

### DIFF
--- a/1.20/scala_2.12-java11-ubuntu/docker-entrypoint.sh
+++ b/1.20/scala_2.12-java11-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/1.20/scala_2.12-java17-ubuntu/docker-entrypoint.sh
+++ b/1.20/scala_2.12-java17-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/1.20/scala_2.12-java8-ubuntu/docker-entrypoint.sh
+++ b/1.20/scala_2.12-java8-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.0/scala_2.12-java11-ubuntu/docker-entrypoint.sh
+++ b/2.0/scala_2.12-java11-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.0/scala_2.12-java17-ubuntu/docker-entrypoint.sh
+++ b/2.0/scala_2.12-java17-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.0/scala_2.12-java21-ubuntu/docker-entrypoint.sh
+++ b/2.0/scala_2.12-java21-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.1/scala_2.12-java11-ubuntu/docker-entrypoint.sh
+++ b/2.1/scala_2.12-java11-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.1/scala_2.12-java17-ubuntu/docker-entrypoint.sh
+++ b/2.1/scala_2.12-java17-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.1/scala_2.12-java21-ubuntu/docker-entrypoint.sh
+++ b/2.1/scala_2.12-java21-ubuntu/docker-entrypoint.sh
@@ -108,7 +108,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.2/scala_2.12-java11-ubuntu/docker-entrypoint.sh
+++ b/2.2/scala_2.12-java11-ubuntu/docker-entrypoint.sh
@@ -101,7 +101,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.2/scala_2.12-java17-ubuntu/docker-entrypoint.sh
+++ b/2.2/scala_2.12-java17-ubuntu/docker-entrypoint.sh
@@ -101,7 +101,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue

--- a/2.2/scala_2.12-java21-ubuntu/docker-entrypoint.sh
+++ b/2.2/scala_2.12-java21-ubuntu/docker-entrypoint.sh
@@ -101,7 +101,7 @@ process_flink_properties() {
     local OLD_IFS="$IFS"
     IFS=$'\n'
     for prop in $flink_properties_content; do
-        prop=$(echo $prop | tr -d '[:space:]')
+        prop=$(echo "$prop" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ -z "$prop" ]; then
             continue


### PR DESCRIPTION
### Motivation

  When FLINK_PROPERTIES contains values with spaces (e.g. JVM options like
  `--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --enable-preview`),
  the entrypoint script strips all whitespace using `tr -d '[:space:]'`, causing
  the options to be concatenated and become invalid.

  ### Changes

  Replace `tr -d '[:space:]'` with `sed 's/^[[:space:]]*//;s/[[:space:]]*$//'`
  to only trim leading and trailing whitespace, preserving spaces within values.

  Applied to all affected versions: 1.20, 2.0, 2.1, 2.2.

  ### Testing

  Verified with Docker Compose using a Flink 1.20.3 image with the fixed
  entrypoint mounted. The WARNING about concatenated module options no longer
  appears in the logs.

  ### Related

  https://issues.apache.org/jira/browse/FLINK-38587