### PR TITLE
[FLINK-39443][release] Update dev-master to point to 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ name: "CI"
 on: [push, pull_request]
 
 env:
-  FLINK_TAR_URL: "https://s3.amazonaws.com/flink-nightly/flink-2.3-SNAPSHOT-bin-scala_2.12.tgz"
+  FLINK_TAR_URL: "https://s3.amazonaws.com/flink-nightly/flink-2.4-SNAPSHOT-bin-scala_2.12.tgz"
 
 jobs:
   ci:


### PR DESCRIPTION
Analogous to https://github.com/apache/flink-docker/pull/243, setting things up for 2.4