### PR TITLE
[INFRA-27887] Use pinned allowed versions for actions

### DIFF
--- a/.github/workflows/check-if-actions-allowed.yml
+++ b/.github/workflows/check-if-actions-allowed.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The action is inspired by
+# If versions are not allowed
+# Check https://github.com/apache/infrastructure-actions actions.yml for allowed versions nd use them
+# Or create a PR there to allow required versions
+name: CI checking if required versions are allowed by parent Apache Infra
+
+on:
+  # If you want to run this workflow manually, keep `workflow_dispatch`. Otherwise, remove this trigger.
+  workflow_dispatch:
+  # Trigger the workflow on push or pull requests when the contents of your `.github` directory change.
+  # Note: the cheeck-project-actions.yml workflow inspects the `.github/workflows` and `.github/actions` directories.
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/**"
+  pull_request:
+    paths:
+      - ".github/**"
+
+permissions:
+  # Only read access is required.
+  contents: read
+  # All other permissions are "none".
+
+jobs:
+  # This is the job that verifies your project's usage of approved GitHub actions
+  check:
+    name: Check actions usage
+    uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
+    permissions:
+      # Only read access to the repository's content.
+      contents: read
+      # All other permissions are "none".
+      # Optionally, you can specify a different repository and/or ref to check. These options are passed to
+      # GitHub actions/checkout, see https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
+      #with:
+      #repository: apache/my-project
+      #ref: my-branch
+      #fetch-depth:
+      #submodules:

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -89,13 +89,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -140,7 +140,7 @@ jobs:
           echo "Image tags: $TAGS"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: ${{ matrix.flink_version }}/scala_2.12-java${{ matrix.java_version }}-ubuntu
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -53,13 +53,13 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: "Log in to the Container registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -77,7 +77,7 @@ jobs:
         run: env
 
       - name: "Build and push Docker images (supported platforms)"
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@aefd381cbaa93c62a1e8b02194ae420cc36269d2
         with:
           files: |
             .github/workflows/docker-bake.hcl


### PR DESCRIPTION
After required actions are added into whitelist with pinned versions
https://github.com/apache/infrastructure-actions/pull/803 

this could continue to unblock CI
1. The PR adds a workflow to check whether used versions are allowed by Apache or not
2. It uses pinned versions from the whitelists https://github.com/apache/infrastructure-actions/blob/main/actions.yml


this is to mitigate the problem of failing actions like 

https://github.com/apache/flink-docker/actions/runs/25377968285
```
The actions docker/setup-qemu-action@v3, docker/setup-buildx-action@v3, docker/login-action@v3, and docker/build-push-action@v5 are not allowed in apache/flink-docker because all actions must be from a repository owned by your enterprise, created by GitHub
```