### PR TITLE
[FLINK-39796] Update docker bake action

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -77,7 +77,7 @@ jobs:
         run: env
 
       - name: "Build and push Docker images (supported platforms)"
-        uses: docker/bake-action@aefd381cbaa93c62a1e8b02194ae420cc36269d2
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584
         with:
           files: |
             .github/workflows/docker-bake.hcl


### PR DESCRIPTION
## What is the purpose of the change

Update the pinned `docker/bake-action` used by the snapshot publishing workflow to a Buildx-compatible version.

## Brief change log

- Update `docker/bake-action` from the old v4.7.0 commit to the Apache Infra-allowed v7.2.0 commit.

## Verifying this change

- Parsed `.github/workflows/snapshot.yml` successfully with Ruby YAML.
- Confirmed the new action SHA is listed in Apache Infra allowed actions: https://github.com/apache/infrastructure-actions/blob/main/actions.yml under `docker/bake-action`.
- Verified that upstream `docker/bake-action` tag `v7.2.0` resolves to the same commit:

  ```bash
  git ls-remote --tags https://github.com/docker/bake-action.git refs/tags/v7.2.0
  # 6614cfa25eff9a0b2b2697efb0b6159e7680d584 refs/tags/v7.2.0
  ```

This fixes the GitHub Actions failure reported in FLINK-39796: `docker/bake-action < v5 is not compatible with buildx >= 0.20.0`.