### PR TITLE
[FLINK-39796] Fix snapshot bake by pinning bake-action to local source

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -79,6 +79,14 @@ jobs:
       - name: "Build and push Docker images (supported platforms)"
         uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584
         with:
+          # bake-action >= v7 defaults an unset "source" to the workflow's git
+          # context and bakes it as a remote ref, which reads docker-bake.hcl and
+          # the build context from the triggering commit on master. This workflow
+          # needs the local working tree instead: the Dockerfile is generated at
+          # runtime by add-custom.sh, and the docker-metadata-action target it
+          # inherits is only defined in the checked-out dev-* branch. Pin to the
+          # local source to restore the pre-v7 behavior.
+          source: .
           files: |
             .github/workflows/docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}


### PR DESCRIPTION
## Problem

The `Publish SNAPSHOTs` workflow has been failing on every run. Each matrix job dies at the *Build and push Docker images* step with:

```
ERROR: failed to find target docker-metadata-action
##[error]cannot parse bake definitions: ERROR: failed to find target docker-metadata-action
```

## Root cause

`docker-bake.hcl`'s `bake-platform` target does `inherits = ["docker-metadata-action"]`. That target is defined as an empty stub (`target "docker-metadata-action" {}`) on every `dev-*` branch, but **not on `master`**.

The regression was triggered by [FLINK-39796] bumping `docker/bake-action` from v4 to v7. v7 changed the default of an unset `source` input: instead of baking the **local working tree**, it now falls back to the workflow's own git context and bakes it as a **remote ref**, so buildx fetches `docker-bake.hcl` (and the build context) from the triggering commit on `master`:

```
docker buildx bake https://github.com/apache/flink-docker.git#<sha> --file .github/workflows/docker-bake.hcl ... bake-platform
```

Since the job checks out a `dev-*` branch but v7 reads `master`, two things break:

1. `master`'s `docker-bake.hcl` lacks the `docker-metadata-action` stub → `inherits` fails.
2. The snapshot Dockerfile is generated at runtime by `add-custom.sh` into the local working tree and is never committed, so a remote bake context could not find `$DOCKER_FILE` anyway.

This is why the workflow was green on v4 (which baked the local `dev-*` checkout that has both the stub and the generated Dockerfile) and red on v7.

## Fix

Set `source: .` on the bake step to restore the pre-v7 behavior of baking the local working tree. This resolves both issues at once: the checked-out `dev-*` tree contains both the generated Dockerfile and the `docker-metadata-action` stub.

## Notes

- An alternative/complementary change would be to add `target "docker-metadata-action" {}` to `master`'s `docker-bake.hcl` to match the `dev-*` branches. That alone is **not** sufficient under v7's remote bake, because the runtime-generated Dockerfile still wouldn't exist in the remote context — hence pinning `source: .` is the actual fix.
