### PR TITLE
[FLINK-39924] Fix jemalloc narenas configuration by using actual container CPU allowance

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -120,6 +120,54 @@ process_flink_properties() {
     fi
 }
 
+# FLINK-39924: jemalloc's default narenas = 4 * ncpus is taken from
+# /proc/cpuinfo (host CPU count), ignoring the container's quota
+# and idle arenas hold dirty pages until dirty_decay_ms, inflating
+# RSS. Derive narenas from the cgroup CPU quota instead.
+configure_jemalloc_narenas() {
+    case ",${MALLOC_CONF}," in
+        *,narenas:*)
+            echo "jemalloc: respecting user-supplied narenas in MALLOC_CONF=${MALLOC_CONF}"
+            return
+            ;;
+    esac
+
+    local cpus="" cpu_quota cpu_period
+    if [ -r /sys/fs/cgroup/cpu.max ]; then
+        # cgroup v2
+        read -r cpu_quota cpu_period < /sys/fs/cgroup/cpu.max
+        if [ "$cpu_quota" != "max" ] && [ -n "$cpu_period" ] && [ "$cpu_period" -gt 0 ]; then
+            cpus=$(( (cpu_quota + cpu_period - 1) / cpu_period ))
+        fi
+    elif [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -r /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+        # cgroup v1
+        cpu_quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+        cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+        if [ "$cpu_quota" -gt 0 ] && [ "$cpu_period" -gt 0 ]; then
+            cpus=$(( (cpu_quota + cpu_period - 1) / cpu_period ))
+        fi
+    fi
+    # Fall back to nproc when no quota is set (cpuset-pinned / unlimited).
+    if [ -z "$cpus" ] || [ "$cpus" -le 0 ]; then
+        cpus=$(nproc 2>/dev/null || echo 1)
+    fi
+
+    local narenas
+    if [ "$cpus" -le 1 ]; then
+        narenas=1
+    else
+        narenas=$(( cpus * 4 ))
+    fi
+
+    if [ -z "${MALLOC_CONF}" ]; then
+        export MALLOC_CONF="narenas:${narenas}"
+        echo "jemalloc: setting MALLOC_CONF=${MALLOC_CONF} (detected ${cpus} CPUs)"
+    else
+        export MALLOC_CONF="${MALLOC_CONF},narenas:${narenas}"
+        echo "jemalloc: appended narenas, MALLOC_CONF=${MALLOC_CONF} (detected ${cpus} CPUs)"
+    fi
+}
+
 maybe_enable_jemalloc() {
     if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
         JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
@@ -135,7 +183,10 @@ maybe_enable_jemalloc() {
                 MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
             fi
             echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
+            return
         fi
+
+        configure_jemalloc_narenas
     fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set jemalloc arena count using **`ncpus` derived from the container's cgroup CPU quota** with the same formula as jemalloc's default (`4 × ncpus`, or `1` when `ncpus == 1`)  

Note jemalloc default is not container aware and **uses host machine's CPU count**: https://jemalloc.net/jemalloc.3.html#opt.narenas

## Why are the changes needed?

Large number of arenas leads to infrequently used arenas, infrequently used arenas hold dirty pages for dirty_decay_ms before releasing memory to OS. We observed excessive memory fragmentation in production, using malloc_stats we identified the most extreme case of fragmentation at 3.91 GB (10.01 GB Resident - 6.1 GB Active) which was significant as the pod has a limit of 16 GB. This was caused by jemalloc arena count misconfigured to higher than expected default as it uses host CPU count. 

- Excessive memory fragmentation contributes to OOMKills
- Excessive memory fragmentation also reduces OS page cache, which impacts performance of operations involving disk read and writes

## Verifying this change

Reproduced on Docker Desktop running on mac book pro with 14 cores. With 6 TaskManagers per cluster configured with 2 GB process size, 1 CPU each and RocksDB state backend. 

| metric | Flink 2.2.1 | Flink 2.2.1 image with fix | changes |
|---|---|---|---|
| peak anon resident set size (RSS) | 1655.9 MB | 1472.7 MB | −183.2 MB (-11.1 %) |
| avg anon RSS | 1477.2 MB | 1273.8 MB | −203.4 MB (-13.7 %) |
| lowest source throughput | 197666 rec | 202947 rec | +2.7 % |
| average source throughput | 208187 rec | 209098 rec | +4.4 % |

See here for reproduction/verification step (4narena image was replaced to use patched image): https://github.com/leekeiabstraction/flink-docker/tree/reproduce-jemalloc-fragmentation/reproduce-jemalloc-fragmentation

## Does this PR introduce any user-facing change?

None, default behaviour of manually override of narenas is preseved.